### PR TITLE
Add aim and PV direction vectors, to support skeletons that have different joint orientations.

### DIFF
--- a/grim_vik.h
+++ b/grim_vik.h
@@ -21,7 +21,7 @@ public:
 
 	virtual MStatus		compute( const MPlug& plug, MDataBlock& data );
 
-	inline void         calculate_orientations( Pose &pose, const MPoint &pole_point, const bool flip );
+	inline void         calculate_orientations( Pose &pose, const MPoint &pole_point, const MVector &aimVectorDirection, const MVector &poleVectorDirection );
 
 	static  void*		creator();
 	static  MStatus		initialize();
@@ -51,6 +51,9 @@ public:
 	static MObject      iLengthBoost;
 	static MObject      iSoftness;
 	static MObject      iTwist;
+
+	static MObject      iAimDirection;
+	static MObject      iPoleVectorDirection;
 
 	// outputs
 	static MObject      oOutTranslate;


### PR DESCRIPTION
When I first tried this plugin I had some trouble figuring out why it wasn't working on some skeletons.  It turned out to be something simple: it assumes a particular joint orientation.  flipOrientation will fix one particular case, but it wouldn't work in all cases.

I fixed this by adding vectors to specify the aim direction (the local vector from each joint to its child) and pole vector direction (the local vector from the elbow to the pole vector).  The default values are (1,0,0) and (0,1,0), which should give the current behavior.  flipOrientation is the same as (-1,0,0) and (0,-1,0).  These vectors don't have to be axis-aligned.
